### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Calling code may be typed as follows.
 In python >= 3.7
 ```python
 # May need [PEP 563](https://www.python.org/dev/peps/pep-0563/) to postpone evaluation of annotations
-# from __future__ import annotations  # Not needed with python>=3.10 or protobuf>=3.20.0
+# from __future__ import annotations  # Not needed with python>=3.11 or protobuf>=3.20.0
 def f(x: MyEnum.ValueType):
     print(x)
 f(MyEnum.Value("HELLO"))


### PR DESCRIPTION
This PR updates the comment about PEP 563 on the current use of enum `ValueType`. 

PEP 563 was announced as default in 3.10, but this decision has been rolled back.
fyi: https://mail.python.org/archives/list/python-dev@python.org/thread/CLVXXPQ2T2LQ5MP2Y53VVQFCXYWQJHKZ/
