### PR TITLE
Prefer typing over typing_extensions for python versions that support it.

### DIFF
--- a/mypy_protobuf/main.py
+++ b/mypy_protobuf/main.py
@@ -86,6 +86,11 @@ PROTO_ENUM_RESERVED = {
     "items",
 }
 
+if sys.version_info > (3, 9):
+    typing_package_name = "typing"
+else:
+    typing_package_name = "typing_extensions"
+
 
 def _mangle_global_identifier(name: str) -> str:
     """
@@ -333,13 +338,13 @@ class PkgWriter(object):
 
             l(f"class {enum_helper_class}:")
             with self._indent():
-                l(
+                l(G
                     "ValueType = {}('ValueType', {})",
                     self._import("typing", "NewType"),
                     self._builtin("int"),
                 )
                 # Alias to the classic shorter definition "V"
-                l("V: {} = ValueType", self._import("typing_extensions", "TypeAlias"))
+                l("V: {} = ValueType", self._import(typing_package_name, "TypeAlias"))
             l(
                 "class {}({}[{}], {}):",
                 etw_helper_class,
@@ -535,14 +540,14 @@ class PkgWriter(object):
         if hf_fields:
             l(
                 "def HasField(self, field_name: {}[{}]) -> {}: ...",
-                self._import("typing_extensions", "Literal"),
+                self._import(typing_package_name, "Literal"),
                 hf_fields_text,
                 self._builtin("bool"),
             )
         if cf_fields:
             l(
                 "def ClearField(self, field_name: {}[{}]) -> None: ...",
-                self._import("typing_extensions", "Literal"),
+                self._import(typing_package_name, "Literal"),
                 cf_fields_text,
             )
 
@@ -551,10 +556,10 @@ class PkgWriter(object):
                 l("@{}", self._import("typing", "overload"))
             l(
                 "def WhichOneof(self, oneof_group: {}[{}]) -> {}[{}] | None: ...",
-                self._import("typing_extensions", "Literal"),
+                self._import(typing_package_name, "Literal"),
                 # Accepts both str and bytes
                 f'"{wo_field}",b"{wo_field}"',
-                self._import("typing_extensions", "Literal"),
+                self._import(typing_package_name, "Literal"),
                 # Returns `str`
                 ",".join(f'"{m}"' for m in members),
             )

--- a/mypy_protobuf/main.py
+++ b/mypy_protobuf/main.py
@@ -338,7 +338,7 @@ class PkgWriter(object):
 
             l(f"class {enum_helper_class}:")
             with self._indent():
-                l(G
+                l(
                     "ValueType = {}('ValueType', {})",
                     self._import("typing", "NewType"),
                     self._builtin("int"),


### PR DESCRIPTION
When using this package I noticed the mypy built types `*.pyi` files still relied on `typing_extensions` after we upgraded to 3.10. I know that `Literal` has been in typing since 3.8+ and was wondering if this kind of change was something you'd want.

This worked for my project, but I'm not aware of the long term vision for this project. We could certainly have smarter shims for this too if we'd like, but this was just my initial cut at trying to reduce the `typing_extension` dependency on the auto-generated files. 