### PR TITLE
grpcio-tools 1.48 was yanked

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ Earlier releases might work, but aren't tested
 
 ### To run typecheckers on code generated with grpc plugin - you'll additionally need
 Earlier releases might work, but aren't tested
-- [grpcio>=1.44.0](https://pypi.org/project/grpcio/)
-- [grpcio-tools>=1.44.0](https://pypi.org/project/grpcio-tools/)
+- [grpcio>=1.47.0](https://pypi.org/project/grpcio/)
+- [grpcio-tools>=1.47.0](https://pypi.org/project/grpcio-tools/)
 - [grpc-stubs>=1.24.9](https://pypi.org/project/grpc-stubs/)
 
 Other configurations may work, but are not continuously tested currently.

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -3,5 +3,5 @@
 protobuf>=3.19.4
 pytest==7.1.2
 grpc-stubs==1.24.11
-grpcio-tools==1.48.0
+grpcio-tools==1.47.0
 types-protobuf>=3.19.12


### PR DESCRIPTION
Go back to 1.47
