### PR TITLE
Add gRPC aio stub and servicer generation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -98,7 +98,7 @@ jobs:
       - name: Run formatters and linters
         run: |
           pip3 install black isort flake8-pyi flake8-noqa flake8-bugbear
-          black --check .
+          black --check --extend-exclude '(_pb2_grpc|_pb2).pyi?$' .
           isort --check . --diff
           flake8 .
       - name: run shellcheck

--- a/mypy_protobuf/main.py
+++ b/mypy_protobuf/main.py
@@ -696,14 +696,14 @@ class PkgWriter(object):
         if method.server_streaming:
             # Union[Iterator[Resp], AsyncIterator[Resp]] is subtyped by Iterator[Resp] and AsyncIterator[Resp].
             # So both can be used in the covariant function return position.
-            iterator = f"{self._import('typing', 'Iterator')}[{result}]"
-            aiterator = f"{self._import('typing', 'AsyncIterator')}[{result}]"
+            iterator = f"{self._import('collections.abc', 'Iterator')}[{result}]"
+            aiterator = f"{self._import('collections.abc', 'AsyncIterator')}[{result}]"
             result = f"{self._import('typing', 'Union')}[{iterator}, {aiterator}]"
         else:
             # Union[Resp, Awaitable[Resp]] is subtyped by Resp and Awaitable[Resp].
             # So both can be used in the covariant function return position.
             # Awaitable[Resp] is equivalent to async def.
-            awaitable = f"{self._import('typing', 'Awaitable')}[{result}]"
+            awaitable = f"{self._import('collections.abc', 'Awaitable')}[{result}]"
             result = f"{self._import('typing', 'Union')}[{result}, {awaitable}]"
         return result
 
@@ -715,8 +715,8 @@ class PkgWriter(object):
         wl("")
         wl(
             "class _MaybeAsyncIterator({}[_T], {}[_T], metaclass={}):",
-            self._import("typing", "AsyncIterator"),
-            self._import("typing", "Iterator"),
+            self._import("collections.abc", "AsyncIterator"),
+            self._import("collections.abc", "Iterator"),
             self._import("abc", "ABCMeta"),
         )
         with self._indent():

--- a/mypy_protobuf/main.py
+++ b/mypy_protobuf/main.py
@@ -663,29 +663,76 @@ class PkgWriter(object):
 
         return ktype, vtype
 
-    def _callable_type(self, method: d.MethodDescriptorProto) -> str:
+    def _callable_type(self, method: d.MethodDescriptorProto, is_async: bool = False) -> str:
+        module = "grpc.aio" if is_async else "grpc"
         if method.client_streaming:
             if method.server_streaming:
-                return self._import("grpc", "StreamStreamMultiCallable")
+                return self._import(module, "StreamStreamMultiCallable")
             else:
-                return self._import("grpc", "StreamUnaryMultiCallable")
+                return self._import(module, "StreamUnaryMultiCallable")
         else:
             if method.server_streaming:
-                return self._import("grpc", "UnaryStreamMultiCallable")
+                return self._import(module, "UnaryStreamMultiCallable")
             else:
-                return self._import("grpc", "UnaryUnaryMultiCallable")
+                return self._import(module, "UnaryUnaryMultiCallable")
 
-    def _input_type(self, method: d.MethodDescriptorProto, use_stream_iterator: bool = True) -> str:
+    def _input_type(self, method: d.MethodDescriptorProto) -> str:
         result = self._import_message(method.input_type)
-        if use_stream_iterator and method.client_streaming:
-            result = f"{self._import('collections.abc', 'Iterator')}[{result}]"
         return result
 
-    def _output_type(self, method: d.MethodDescriptorProto, use_stream_iterator: bool = True) -> str:
-        result = self._import_message(method.output_type)
-        if use_stream_iterator and method.server_streaming:
-            result = f"{self._import('collections.abc', 'Iterator')}[{result}]"
+    def _servicer_input_type(self, method: d.MethodDescriptorProto) -> str:
+        result = self._import_message(method.input_type)
+        if method.client_streaming:
+            # See write_grpc_async_hacks().
+            result = f"_MaybeAsyncIterator[{result}]"
         return result
+
+    def _output_type(self, method: d.MethodDescriptorProto) -> str:
+        result = self._import_message(method.output_type)
+        return result
+
+    def _servicer_output_type(self, method: d.MethodDescriptorProto) -> str:
+        result = self._import_message(method.output_type)
+        if method.server_streaming:
+            # Union[Iterator[Resp], AsyncIterator[Resp]] is subtyped by Iterator[Resp] and AsyncIterator[Resp].
+            # So both can be used in the covariant function return position.
+            iterator = f"{self._import('typing', 'Iterator')}[{result}]"
+            aiterator = f"{self._import('typing', 'AsyncIterator')}[{result}]"
+            result = f"{self._import('typing', 'Union')}[{iterator}, {aiterator}]"
+        else:
+            # Union[Resp, Awaitable[Resp]] is subtyped by Resp and Awaitable[Resp].
+            # So both can be used in the covariant function return position.
+            # Awaitable[Resp] is equivalent to async def.
+            awaitable = f"{self._import('typing', 'Awaitable')}[{result}]"
+            result = f"{self._import('typing', 'Union')}[{result}, {awaitable}]"
+        return result
+
+    def write_grpc_async_hacks(self) -> None:
+        wl = self._write_line
+        # _MaybeAsyncIterator[Req] is supertyped by Iterator[Req] and AsyncIterator[Req].
+        # So both can be used in the contravariant function parameter position.
+        wl("_T = {}('_T')", self._import("typing", "TypeVar"))
+        wl("")
+        wl(
+            "class _MaybeAsyncIterator({}[_T], {}[_T], metaclass={}):",
+            self._import("typing", "AsyncIterator"),
+            self._import("typing", "Iterator"),
+            self._import("abc", "ABCMeta"),
+        )
+        with self._indent():
+            wl("...")
+        wl("")
+
+        # _ServicerContext is supertyped by grpc.ServicerContext and grpc.aio.ServicerContext
+        # So both can be used in the contravariant function parameter position.
+        wl(
+            "class _ServicerContext({}, {}):  # type: ignore",
+            self._import("grpc", "ServicerContext"),
+            self._import("grpc.aio", "ServicerContext"),
+        )
+        with self._indent():
+            wl("...")
+        wl("")
 
     def write_grpc_methods(self, service: d.ServiceDescriptorProto, scl_prefix: SourceCodeLocation) -> None:
         wl = self._write_line
@@ -701,12 +748,12 @@ class PkgWriter(object):
             with self._indent():
                 wl("self,")
                 input_name = "request_iterator" if method.client_streaming else "request"
-                input_type = self._input_type(method)
+                input_type = self._servicer_input_type(method)
                 wl(f"{input_name}: {input_type},")
-                wl("context: {},", self._import("grpc", "ServicerContext"))
+                wl("context: _ServicerContext,")
             wl(
                 ") -> {}:{}",
-                self._output_type(method),
+                self._servicer_output_type(method),
                 " ..." if not self._has_comments(scl) else "",
             )
             if self._has_comments(scl):
@@ -714,7 +761,7 @@ class PkgWriter(object):
                     if not self._write_comments(scl):
                         wl("...")
 
-    def write_grpc_stub_methods(self, service: d.ServiceDescriptorProto, scl_prefix: SourceCodeLocation) -> None:
+    def write_grpc_stub_methods(self, service: d.ServiceDescriptorProto, scl_prefix: SourceCodeLocation, is_async: bool = False) -> None:
         wl = self._write_line
         methods = [(i, m) for i, m in enumerate(service.method) if m.name not in PYTHON_RESERVED]
         if not methods:
@@ -723,10 +770,10 @@ class PkgWriter(object):
         for i, method in methods:
             scl = scl_prefix + [d.ServiceDescriptorProto.METHOD_FIELD_NUMBER, i]
 
-            wl("{}: {}[", method.name, self._callable_type(method))
+            wl("{}: {}[", method.name, self._callable_type(method, is_async=is_async))
             with self._indent():
-                wl("{},", self._input_type(method, False))
-                wl("{},", self._output_type(method, False))
+                wl("{},", self._input_type(method))
+                wl("{},", self._output_type(method))
             wl("]")
             self._write_comments(scl)
 
@@ -743,15 +790,29 @@ class PkgWriter(object):
             scl = scl_prefix + [i]
 
             # The stub client
-            wl(f"class {service.name}Stub:")
+            wl(
+                "class {}Stub:",
+                service.name,
+            )
             with self._indent():
                 if self._write_comments(scl):
                     wl("")
-                wl(
-                    "def __init__(self, channel: {}) -> None: ...",
-                    self._import("grpc", "Channel"),
-                )
+                # To support casting into FooAsyncStub, allow both Channel and aio.Channel here.
+                channel = f"{self._import('typing', 'Union')}[{self._import('grpc', 'Channel')}, {self._import('grpc.aio', 'Channel')}]"
+                wl("def __init__(self, channel: {}) -> None: ...", channel)
                 self.write_grpc_stub_methods(service, scl)
+            wl("")
+
+            # The (fake) async stub client
+            wl(
+                "class {}AsyncStub:",
+                service.name,
+            )
+            with self._indent():
+                if self._write_comments(scl):
+                    wl("")
+                # No __init__ since this isn't a real class (yet), and requires manual casting to work.
+                self.write_grpc_stub_methods(service, scl, is_async=True)
             wl("")
 
             # The service definition interface
@@ -765,11 +826,13 @@ class PkgWriter(object):
                     wl("")
                 self.write_grpc_methods(service, scl)
             wl("")
+            server = self._import("grpc", "Server")
+            aserver = self._import("grpc.aio", "Server")
             wl(
                 "def add_{}Servicer_to_server(servicer: {}Servicer, server: {}) -> None: ...",
                 service.name,
                 service.name,
-                self._import("grpc", "Server"),
+                f"{self._import('typing', 'Union')}[{server}, {aserver}]",
             )
             wl("")
 
@@ -960,6 +1023,7 @@ def generate_mypy_grpc_stubs(
             relax_strict_optional_primitives,
             grpc=True,
         )
+        pkg_writer.write_grpc_async_hacks()
         pkg_writer.write_grpc_services(fd.service, [d.FileDescriptorProto.SERVICE_FIELD_NUMBER])
 
         assert name == fd.name

--- a/run_test.sh
+++ b/run_test.sh
@@ -152,7 +152,7 @@ for PY_VER in $PY_VER_UNIT_TESTS; do
         export MYPYPATH=$MYPYPATH:test/generated
 
         # Run mypy
-        MODULES=( "-m" "test" )
+        MODULES=( -m test.test_generated_mypy -m test.test_grpc_usage -m test.test_grpc_async_usage )
         mypy --custom-typeshed-dir="$CUSTOM_TYPESHED_DIR" --python-executable=$UNIT_TESTS_VENV/bin/python --python-version="$PY_VER_MYPY_TARGET" "${MODULES[@]}"
 
         # Run stubtest. Stubtest does not work with python impl - only cpp impl

--- a/stubtest_allowlist.txt
+++ b/stubtest_allowlist.txt
@@ -48,6 +48,10 @@ testproto.readme_enum_pb2._?MyEnum(EnumTypeWrapper)?
 testproto.nested.nested_pb2.AnotherNested._?NestedEnum(EnumTypeWrapper)?
 testproto.nested.nested_pb2.AnotherNested.NestedMessage._?NestedEnum2(EnumTypeWrapper)?
 
+# Our fake async stubs are not there at runtime (yet)
+testproto.grpc.dummy_pb2_grpc.DummyServiceAsyncStub
+testproto.grpc.import_pb2_grpc.SimpleServiceAsyncStub
+
 # Part of an "EXPERIMENTAL API" according to comment. Not documented.
 testproto.grpc.dummy_pb2_grpc.DummyService
 testproto.grpc.import_pb2_grpc.SimpleService

--- a/test/generated/testproto/grpc/dummy_pb2_grpc.pyi
+++ b/test/generated/testproto/grpc/dummy_pb2_grpc.pyi
@@ -3,6 +3,7 @@
 isort:skip_file
 https://github.com/vmagamedov/grpclib/blob/master/tests/dummy.proto"""
 import abc
+import collections.abc
 import grpc
 import grpc.aio
 import testproto.grpc.dummy_pb2
@@ -10,7 +11,7 @@ import typing
 
 _T = typing.TypeVar('_T')
 
-class _MaybeAsyncIterator(typing.AsyncIterator[_T], typing.Iterator[_T], metaclass=abc.ABCMeta):
+class _MaybeAsyncIterator(collections.abc.AsyncIterator[_T], collections.abc.Iterator[_T], metaclass=abc.ABCMeta):
     ...
 
 class _ServicerContext(grpc.ServicerContext, grpc.aio.ServicerContext):  # type: ignore
@@ -73,28 +74,28 @@ class DummyServiceServicer(metaclass=abc.ABCMeta):
         self,
         request: testproto.grpc.dummy_pb2.DummyRequest,
         context: _ServicerContext,
-    ) -> typing.Union[testproto.grpc.dummy_pb2.DummyReply, typing.Awaitable[testproto.grpc.dummy_pb2.DummyReply]]:
+    ) -> typing.Union[testproto.grpc.dummy_pb2.DummyReply, collections.abc.Awaitable[testproto.grpc.dummy_pb2.DummyReply]]:
         """UnaryUnary"""
     @abc.abstractmethod
     def UnaryStream(
         self,
         request: testproto.grpc.dummy_pb2.DummyRequest,
         context: _ServicerContext,
-    ) -> typing.Union[typing.Iterator[testproto.grpc.dummy_pb2.DummyReply], typing.AsyncIterator[testproto.grpc.dummy_pb2.DummyReply]]:
+    ) -> typing.Union[collections.abc.Iterator[testproto.grpc.dummy_pb2.DummyReply], collections.abc.AsyncIterator[testproto.grpc.dummy_pb2.DummyReply]]:
         """UnaryStream"""
     @abc.abstractmethod
     def StreamUnary(
         self,
         request_iterator: _MaybeAsyncIterator[testproto.grpc.dummy_pb2.DummyRequest],
         context: _ServicerContext,
-    ) -> typing.Union[testproto.grpc.dummy_pb2.DummyReply, typing.Awaitable[testproto.grpc.dummy_pb2.DummyReply]]:
+    ) -> typing.Union[testproto.grpc.dummy_pb2.DummyReply, collections.abc.Awaitable[testproto.grpc.dummy_pb2.DummyReply]]:
         """StreamUnary"""
     @abc.abstractmethod
     def StreamStream(
         self,
         request_iterator: _MaybeAsyncIterator[testproto.grpc.dummy_pb2.DummyRequest],
         context: _ServicerContext,
-    ) -> typing.Union[typing.Iterator[testproto.grpc.dummy_pb2.DummyReply], typing.AsyncIterator[testproto.grpc.dummy_pb2.DummyReply]]:
+    ) -> typing.Union[collections.abc.Iterator[testproto.grpc.dummy_pb2.DummyReply], collections.abc.AsyncIterator[testproto.grpc.dummy_pb2.DummyReply]]:
         """StreamStream"""
 
 def add_DummyServiceServicer_to_server(servicer: DummyServiceServicer, server: typing.Union[grpc.Server, grpc.aio.Server]) -> None: ...

--- a/test/generated/testproto/grpc/dummy_pb2_grpc.pyi
+++ b/test/generated/testproto/grpc/dummy_pb2_grpc.pyi
@@ -3,14 +3,23 @@
 isort:skip_file
 https://github.com/vmagamedov/grpclib/blob/master/tests/dummy.proto"""
 import abc
-import collections.abc
 import grpc
+import grpc.aio
 import testproto.grpc.dummy_pb2
+import typing
+
+_T = typing.TypeVar('_T')
+
+class _MaybeAsyncIterator(typing.AsyncIterator[_T], typing.Iterator[_T], metaclass=abc.ABCMeta):
+    ...
+
+class _ServicerContext(grpc.ServicerContext, grpc.aio.ServicerContext):  # type: ignore
+    ...
 
 class DummyServiceStub:
     """DummyService"""
 
-    def __init__(self, channel: grpc.Channel) -> None: ...
+    def __init__(self, channel: typing.Union[grpc.Channel, grpc.aio.Channel]) -> None: ...
     UnaryUnary: grpc.UnaryUnaryMultiCallable[
         testproto.grpc.dummy_pb2.DummyRequest,
         testproto.grpc.dummy_pb2.DummyReply,
@@ -32,6 +41,30 @@ class DummyServiceStub:
     ]
     """StreamStream"""
 
+class DummyServiceAsyncStub:
+    """DummyService"""
+
+    UnaryUnary: grpc.aio.UnaryUnaryMultiCallable[
+        testproto.grpc.dummy_pb2.DummyRequest,
+        testproto.grpc.dummy_pb2.DummyReply,
+    ]
+    """UnaryUnary"""
+    UnaryStream: grpc.aio.UnaryStreamMultiCallable[
+        testproto.grpc.dummy_pb2.DummyRequest,
+        testproto.grpc.dummy_pb2.DummyReply,
+    ]
+    """UnaryStream"""
+    StreamUnary: grpc.aio.StreamUnaryMultiCallable[
+        testproto.grpc.dummy_pb2.DummyRequest,
+        testproto.grpc.dummy_pb2.DummyReply,
+    ]
+    """StreamUnary"""
+    StreamStream: grpc.aio.StreamStreamMultiCallable[
+        testproto.grpc.dummy_pb2.DummyRequest,
+        testproto.grpc.dummy_pb2.DummyReply,
+    ]
+    """StreamStream"""
+
 class DummyServiceServicer(metaclass=abc.ABCMeta):
     """DummyService"""
 
@@ -39,29 +72,29 @@ class DummyServiceServicer(metaclass=abc.ABCMeta):
     def UnaryUnary(
         self,
         request: testproto.grpc.dummy_pb2.DummyRequest,
-        context: grpc.ServicerContext,
-    ) -> testproto.grpc.dummy_pb2.DummyReply:
+        context: _ServicerContext,
+    ) -> typing.Union[testproto.grpc.dummy_pb2.DummyReply, typing.Awaitable[testproto.grpc.dummy_pb2.DummyReply]]:
         """UnaryUnary"""
     @abc.abstractmethod
     def UnaryStream(
         self,
         request: testproto.grpc.dummy_pb2.DummyRequest,
-        context: grpc.ServicerContext,
-    ) -> collections.abc.Iterator[testproto.grpc.dummy_pb2.DummyReply]:
+        context: _ServicerContext,
+    ) -> typing.Union[typing.Iterator[testproto.grpc.dummy_pb2.DummyReply], typing.AsyncIterator[testproto.grpc.dummy_pb2.DummyReply]]:
         """UnaryStream"""
     @abc.abstractmethod
     def StreamUnary(
         self,
-        request_iterator: collections.abc.Iterator[testproto.grpc.dummy_pb2.DummyRequest],
-        context: grpc.ServicerContext,
-    ) -> testproto.grpc.dummy_pb2.DummyReply:
+        request_iterator: _MaybeAsyncIterator[testproto.grpc.dummy_pb2.DummyRequest],
+        context: _ServicerContext,
+    ) -> typing.Union[testproto.grpc.dummy_pb2.DummyReply, typing.Awaitable[testproto.grpc.dummy_pb2.DummyReply]]:
         """StreamUnary"""
     @abc.abstractmethod
     def StreamStream(
         self,
-        request_iterator: collections.abc.Iterator[testproto.grpc.dummy_pb2.DummyRequest],
-        context: grpc.ServicerContext,
-    ) -> collections.abc.Iterator[testproto.grpc.dummy_pb2.DummyReply]:
+        request_iterator: _MaybeAsyncIterator[testproto.grpc.dummy_pb2.DummyRequest],
+        context: _ServicerContext,
+    ) -> typing.Union[typing.Iterator[testproto.grpc.dummy_pb2.DummyReply], typing.AsyncIterator[testproto.grpc.dummy_pb2.DummyReply]]:
         """StreamStream"""
 
-def add_DummyServiceServicer_to_server(servicer: DummyServiceServicer, server: grpc.Server) -> None: ...
+def add_DummyServiceServicer_to_server(servicer: DummyServiceServicer, server: typing.Union[grpc.Server, grpc.aio.Server]) -> None: ...

--- a/test/generated/testproto/grpc/import_pb2_grpc.pyi
+++ b/test/generated/testproto/grpc/import_pb2_grpc.pyi
@@ -3,6 +3,7 @@
 isort:skip_file
 """
 import abc
+import collections.abc
 import google.protobuf.empty_pb2
 import grpc
 import grpc.aio
@@ -11,7 +12,7 @@ import typing
 
 _T = typing.TypeVar('_T')
 
-class _MaybeAsyncIterator(typing.AsyncIterator[_T], typing.Iterator[_T], metaclass=abc.ABCMeta):
+class _MaybeAsyncIterator(collections.abc.AsyncIterator[_T], collections.abc.Iterator[_T], metaclass=abc.ABCMeta):
     ...
 
 class _ServicerContext(grpc.ServicerContext, grpc.aio.ServicerContext):  # type: ignore
@@ -62,20 +63,20 @@ class SimpleServiceServicer(metaclass=abc.ABCMeta):
         self,
         request: google.protobuf.empty_pb2.Empty,
         context: _ServicerContext,
-    ) -> typing.Union[testproto.test_pb2.Simple1, typing.Awaitable[testproto.test_pb2.Simple1]]:
+    ) -> typing.Union[testproto.test_pb2.Simple1, collections.abc.Awaitable[testproto.test_pb2.Simple1]]:
         """UnaryUnary"""
     @abc.abstractmethod
     def UnaryStream(
         self,
         request: testproto.test_pb2.Simple1,
         context: _ServicerContext,
-    ) -> typing.Union[google.protobuf.empty_pb2.Empty, typing.Awaitable[google.protobuf.empty_pb2.Empty]]:
+    ) -> typing.Union[google.protobuf.empty_pb2.Empty, collections.abc.Awaitable[google.protobuf.empty_pb2.Empty]]:
         """UnaryStream"""
     @abc.abstractmethod
     def NoComment(
         self,
         request: testproto.test_pb2.Simple1,
         context: _ServicerContext,
-    ) -> typing.Union[google.protobuf.empty_pb2.Empty, typing.Awaitable[google.protobuf.empty_pb2.Empty]]: ...
+    ) -> typing.Union[google.protobuf.empty_pb2.Empty, collections.abc.Awaitable[google.protobuf.empty_pb2.Empty]]: ...
 
 def add_SimpleServiceServicer_to_server(servicer: SimpleServiceServicer, server: typing.Union[grpc.Server, grpc.aio.Server]) -> None: ...

--- a/test/generated/testproto/grpc/import_pb2_grpc.pyi
+++ b/test/generated/testproto/grpc/import_pb2_grpc.pyi
@@ -5,12 +5,22 @@ isort:skip_file
 import abc
 import google.protobuf.empty_pb2
 import grpc
+import grpc.aio
 import testproto.test_pb2
+import typing
+
+_T = typing.TypeVar('_T')
+
+class _MaybeAsyncIterator(typing.AsyncIterator[_T], typing.Iterator[_T], metaclass=abc.ABCMeta):
+    ...
+
+class _ServicerContext(grpc.ServicerContext, grpc.aio.ServicerContext):  # type: ignore
+    ...
 
 class SimpleServiceStub:
     """SimpleService"""
 
-    def __init__(self, channel: grpc.Channel) -> None: ...
+    def __init__(self, channel: typing.Union[grpc.Channel, grpc.aio.Channel]) -> None: ...
     UnaryUnary: grpc.UnaryUnaryMultiCallable[
         google.protobuf.empty_pb2.Empty,
         testproto.test_pb2.Simple1,
@@ -26,6 +36,24 @@ class SimpleServiceStub:
         google.protobuf.empty_pb2.Empty,
     ]
 
+class SimpleServiceAsyncStub:
+    """SimpleService"""
+
+    UnaryUnary: grpc.aio.UnaryUnaryMultiCallable[
+        google.protobuf.empty_pb2.Empty,
+        testproto.test_pb2.Simple1,
+    ]
+    """UnaryUnary"""
+    UnaryStream: grpc.aio.UnaryUnaryMultiCallable[
+        testproto.test_pb2.Simple1,
+        google.protobuf.empty_pb2.Empty,
+    ]
+    """UnaryStream"""
+    NoComment: grpc.aio.UnaryUnaryMultiCallable[
+        testproto.test_pb2.Simple1,
+        google.protobuf.empty_pb2.Empty,
+    ]
+
 class SimpleServiceServicer(metaclass=abc.ABCMeta):
     """SimpleService"""
 
@@ -33,21 +61,21 @@ class SimpleServiceServicer(metaclass=abc.ABCMeta):
     def UnaryUnary(
         self,
         request: google.protobuf.empty_pb2.Empty,
-        context: grpc.ServicerContext,
-    ) -> testproto.test_pb2.Simple1:
+        context: _ServicerContext,
+    ) -> typing.Union[testproto.test_pb2.Simple1, typing.Awaitable[testproto.test_pb2.Simple1]]:
         """UnaryUnary"""
     @abc.abstractmethod
     def UnaryStream(
         self,
         request: testproto.test_pb2.Simple1,
-        context: grpc.ServicerContext,
-    ) -> google.protobuf.empty_pb2.Empty:
+        context: _ServicerContext,
+    ) -> typing.Union[google.protobuf.empty_pb2.Empty, typing.Awaitable[google.protobuf.empty_pb2.Empty]]:
         """UnaryStream"""
     @abc.abstractmethod
     def NoComment(
         self,
         request: testproto.test_pb2.Simple1,
-        context: grpc.ServicerContext,
-    ) -> google.protobuf.empty_pb2.Empty: ...
+        context: _ServicerContext,
+    ) -> typing.Union[google.protobuf.empty_pb2.Empty, typing.Awaitable[google.protobuf.empty_pb2.Empty]]: ...
 
-def add_SimpleServiceServicer_to_server(servicer: SimpleServiceServicer, server: grpc.Server) -> None: ...
+def add_SimpleServiceServicer_to_server(servicer: SimpleServiceServicer, server: typing.Union[grpc.Server, grpc.aio.Server]) -> None: ...

--- a/test/test_grpc_async_usage.py
+++ b/test/test_grpc_async_usage.py
@@ -1,0 +1,68 @@
+import typing
+
+import grpc.aio
+import pytest
+from testproto.grpc import dummy_pb2, dummy_pb2_grpc
+
+ADDRESS = "localhost:22223"
+
+
+class Servicer(dummy_pb2_grpc.DummyServiceServicer):
+    async def UnaryUnary(
+        self,
+        request: dummy_pb2.DummyRequest,
+        context: grpc.aio.ServicerContext,
+    ) -> dummy_pb2.DummyReply:
+        return dummy_pb2.DummyReply(value=request.value[::-1])
+
+    async def UnaryStream(
+        self,
+        request: dummy_pb2.DummyRequest,
+        context: grpc.aio.ServicerContext,
+    ) -> typing.AsyncIterator[dummy_pb2.DummyReply]:
+        for char in request.value:
+            yield dummy_pb2.DummyReply(value=char)
+
+    async def StreamUnary(
+        self,
+        request: typing.AsyncIterator[dummy_pb2.DummyRequest],
+        context: grpc.aio.ServicerContext,
+    ) -> dummy_pb2.DummyReply:
+        values = [data.value async for data in request]
+        return dummy_pb2.DummyReply(value="".join(values))
+
+    async def StreamStream(
+        self,
+        request: typing.AsyncIterator[dummy_pb2.DummyRequest],
+        context: grpc.aio.ServicerContext,
+    ) -> typing.AsyncIterator[dummy_pb2.DummyReply]:
+        async for data in request:
+            yield dummy_pb2.DummyReply(value=data.value.upper())
+
+
+def make_server() -> grpc.aio.Server:
+    server = grpc.aio.server()
+    servicer = Servicer()
+    server.add_insecure_port(ADDRESS)
+    dummy_pb2_grpc.add_DummyServiceServicer_to_server(servicer, server)
+    return server
+
+
+@pytest.mark.asyncio
+async def test_grpc() -> None:
+    server = make_server()
+    await server.start()
+    async with grpc.aio.insecure_channel(ADDRESS) as channel:
+        client = dummy_pb2_grpc.DummyServiceStub(channel)
+        request = dummy_pb2.DummyRequest(value="cprg")
+        result1 = await client.UnaryUnary(request)
+        result2 = client.UnaryStream(dummy_pb2.DummyRequest(value=result1.value))
+        result2_list = [r async for r in result2]
+        assert len(result2_list) == 4
+        result3 = client.StreamStream(dummy_pb2.DummyRequest(value=part.value) for part in result2_list)
+        result3_list = [r async for r in result3]
+        assert len(result3_list) == 4
+        result4 = await client.StreamUnary(dummy_pb2.DummyRequest(value=part.value) for part in result3_list)
+        assert result4.value == "GRPC"
+
+    await server.stop(None)

--- a/test/test_grpc_async_usage.py
+++ b/test/test_grpc_async_usage.py
@@ -53,7 +53,7 @@ async def test_grpc() -> None:
     server = make_server()
     await server.start()
     async with grpc.aio.insecure_channel(ADDRESS) as channel:
-        client = dummy_pb2_grpc.DummyServiceStub(channel)
+        client: dummy_pb2_grpc.DummyServiceAsyncStub = dummy_pb2_grpc.DummyServiceStub(channel)  # type: ignore
         request = dummy_pb2.DummyRequest(value="cprg")
         result1 = await client.UnaryUnary(request)
         result2 = client.UnaryStream(dummy_pb2.DummyRequest(value=result1.value))

--- a/test_negative/output.expected.3.8
+++ b/test_negative/output.expected.3.8
@@ -85,13 +85,13 @@ test_negative/negative.py:216: error: "DummyReply" has no attribute "not_exists"
 test_negative/negative.py:253: error: Argument 1 of "UnaryUnary" is incompatible with supertype "DummyServiceServicer"; supertype defines the argument type as "DummyRequest"  [override]
 test_negative/negative.py:253: note: This violates the Liskov substitution principle
 test_negative/negative.py:253: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides
-test_negative/negative.py:253: error: Return type "Iterator[DummyReply]" of "UnaryUnary" incompatible with return type "DummyReply" in supertype "DummyServiceServicer"  [override]
+test_negative/negative.py:253: error: Return type "Iterator[DummyReply]" of "UnaryUnary" incompatible with return type "Union[DummyReply, Awaitable[DummyReply]]" in supertype "DummyServiceServicer"  [override]
 test_negative/negative.py:261: error: Argument 1 of "UnaryStream" is incompatible with supertype "DummyServiceServicer"; supertype defines the argument type as "DummyRequest"  [override]
 test_negative/negative.py:261: note: This violates the Liskov substitution principle
 test_negative/negative.py:261: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides
-test_negative/negative.py:261: error: Return type "DummyReply" of "UnaryStream" incompatible with return type "Iterator[DummyReply]" in supertype "DummyServiceServicer"  [override]
-test_negative/negative.py:270: error: Argument 1 of "StreamUnary" is incompatible with supertype "DummyServiceServicer"; supertype defines the argument type as "Iterator[DummyRequest]"  [override]
+test_negative/negative.py:261: error: Return type "DummyReply" of "UnaryStream" incompatible with return type "Union[Iterator[DummyReply], AsyncIterator[DummyReply]]" in supertype "DummyServiceServicer"  [override]
+test_negative/negative.py:270: error: Argument 1 of "StreamUnary" is incompatible with supertype "DummyServiceServicer"; supertype defines the argument type as "_MaybeAsyncIterator[DummyRequest]"  [override]
 test_negative/negative.py:270: note: This violates the Liskov substitution principle
 test_negative/negative.py:270: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides
-test_negative/negative.py:270: error: Return type "Iterator[DummyReply]" of "StreamUnary" incompatible with return type "DummyReply" in supertype "DummyServiceServicer"  [override]
-Found 80 errors in 1 file (checked 2 source files)
+test_negative/negative.py:270: error: Return type "Iterator[DummyReply]" of "StreamUnary" incompatible with return type "Union[DummyReply, Awaitable[DummyReply]]" in supertype "DummyServiceServicer"  [override]
+Found 80 errors in 1 file (checked 4 source files)

--- a/test_negative/output.expected.3.8.omit_linenos
+++ b/test_negative/output.expected.3.8.omit_linenos
@@ -85,13 +85,13 @@ test_negative/negative.py: error: "DummyReply" has no attribute "not_exists"  [a
 test_negative/negative.py: error: Argument 1 of "UnaryUnary" is incompatible with supertype "DummyServiceServicer"; supertype defines the argument type as "DummyRequest"  [override]
 test_negative/negative.py: note: This violates the Liskov substitution principle
 test_negative/negative.py: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides
-test_negative/negative.py: error: Return type "Iterator[DummyReply]" of "UnaryUnary" incompatible with return type "DummyReply" in supertype "DummyServiceServicer"  [override]
+test_negative/negative.py: error: Return type "Iterator[DummyReply]" of "UnaryUnary" incompatible with return type "Union[DummyReply, Awaitable[DummyReply]]" in supertype "DummyServiceServicer"  [override]
 test_negative/negative.py: error: Argument 1 of "UnaryStream" is incompatible with supertype "DummyServiceServicer"; supertype defines the argument type as "DummyRequest"  [override]
 test_negative/negative.py: note: This violates the Liskov substitution principle
 test_negative/negative.py: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides
-test_negative/negative.py: error: Return type "DummyReply" of "UnaryStream" incompatible with return type "Iterator[DummyReply]" in supertype "DummyServiceServicer"  [override]
-test_negative/negative.py: error: Argument 1 of "StreamUnary" is incompatible with supertype "DummyServiceServicer"; supertype defines the argument type as "Iterator[DummyRequest]"  [override]
+test_negative/negative.py: error: Return type "DummyReply" of "UnaryStream" incompatible with return type "Union[Iterator[DummyReply], AsyncIterator[DummyReply]]" in supertype "DummyServiceServicer"  [override]
+test_negative/negative.py: error: Argument 1 of "StreamUnary" is incompatible with supertype "DummyServiceServicer"; supertype defines the argument type as "_MaybeAsyncIterator[DummyRequest]"  [override]
 test_negative/negative.py: note: This violates the Liskov substitution principle
 test_negative/negative.py: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides
-test_negative/negative.py: error: Return type "Iterator[DummyReply]" of "StreamUnary" incompatible with return type "DummyReply" in supertype "DummyServiceServicer"  [override]
-Found 80 errors in 1 file (checked 2 source files)
+test_negative/negative.py: error: Return type "Iterator[DummyReply]" of "StreamUnary" incompatible with return type "Union[DummyReply, Awaitable[DummyReply]]" in supertype "DummyServiceServicer"  [override]
+Found 80 errors in 1 file (checked 4 source files)

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -2,6 +2,7 @@
 # generated code.
 protobuf==4.21.12
 pytest==7.2.1
+pytest-asyncio==0.20.3
 grpc-stubs==1.24.12
 grpcio-tools==1.51.1
 types-protobuf==4.21.0.5

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -3,6 +3,6 @@
 protobuf==4.21.12
 pytest==7.2.1
 pytest-asyncio==0.20.3
-grpc-stubs==1.24.12
+grpc-stubs==1.24.12.1
 grpcio-tools==1.51.1
 types-protobuf==4.21.0.5


### PR DESCRIPTION
This requires https://github.com/shabbyrobe/grpc-stubs/pull/33

The idea here is to break the problem down into two parts:
1. Modify the Servicer type to accommodate both sync and async implementations
2. Support an async Stub type

I also didn't try to be 100% type safe with this, since the upstream GRPC code makes that very hard/impossible within the constraints of the Python type system. Instead, I aimed for good-enough, where most errors can be caught, but it won't stop you from e.g. using an async Servicer method in a sync Server.

## Servicer type

Here, we need a base Servicer type that can be subtyped by both sync implementations and async implementations. Return types are easy: use a Union which allows either Awaitable return or direct sync return.

Streaming request parameters are more difficult: I used a bit of hackery to allow subtyping by both Iterator and AsyncIterator, by defining a _MaybeAsyncIterator base class that inherits from both Iterator and AsyncIterator, and ignores the resulting method definition clash errors. Since _MaybeAsyncIterator is never actually used in implementations, this seems alright.

## Stub type

I tried all sorts of stuff here:
* A MultiCallable with `@overload` on `__call__` to support both async and sync usage: doesn't work due to https://github.com/python/mypy/issues/8283
* `@overload` on the stub itself, to pick the async or sync MultiCallable: `@overload` only works on functions declared with `def`, and even crazy stuff involving `@property` or `__getattr__` didn't work.

In the end, I settled on defining a new type (that doesn't exist at runtime), AsyncStub, that directly implements the async stub type. Users need to manually cast to this type, but after that initial creation it does work as you'd expect.

This would be improved by adding a `FooAsyncStub = FooStub` into the upstream GRPC generation, since then runtime will match the type stubs, and we could even define an `__init__` to avoid the casting requirement.