### PR TITLE
ubuntu-latest -> ubuntu 20.04 in CI + black 23 formatting

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,9 @@ on:
 jobs:
   run_test:
     name: ${{ matrix.py-ver-mypy-protobuf }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
+    # Some CI issues regarding ubuntu-latest
+    # runs-on: ubuntu-latest
     env:
       PY_VER_MYPY: 3.8.13
       PY_VER_UNIT_TESTS_3: 3.8.13

--- a/mypy_protobuf/main.py
+++ b/mypy_protobuf/main.py
@@ -892,7 +892,7 @@ class PkgWriter(object):
 
         for pkg, items in sorted(self.from_imports.items()):
             self._write_line(f"from {pkg} import (")
-            for (name, reexport_name) in sorted(items):
+            for name, reexport_name in sorted(items):
                 if reexport_name is None:
                     self._write_line(f"    {name},")
                 else:
@@ -972,9 +972,7 @@ def generate_mypy_grpc_stubs(
 
 
 @contextmanager
-def code_generation() -> Iterator[
-    Tuple[plugin_pb2.CodeGeneratorRequest, plugin_pb2.CodeGeneratorResponse],
-]:
+def code_generation() -> Iterator[Tuple[plugin_pb2.CodeGeneratorRequest, plugin_pb2.CodeGeneratorResponse],]:
     if len(sys.argv) > 1 and sys.argv[1] in ("-V", "--version"):
         print("mypy-protobuf " + __version__)
         sys.exit(0)


### PR DESCRIPTION
I could also pin the black version, but we don't really get that much PR traffic to this project, and I'd rather make it a bit smooth to keep up to date with black. Can switch to pinning black's version in the future if it gets annoying.