### PR TITLE
Write info messages to stdout

### DIFF
--- a/mypy_protobuf/main.py
+++ b/mypy_protobuf/main.py
@@ -1005,7 +1005,7 @@ def generate_mypy_stubs(
         output.name = fd.name[:-6].replace("-", "_").replace(".", "/") + "_pb2.pyi"
         output.content = pkg_writer.write()
         if not quiet:
-            print("Writing mypy to", output.name, file=sys.stderr)
+            print("Writing mypy to", output.name, file=sys.stdout)
 
 
 def generate_mypy_grpc_stubs(
@@ -1032,7 +1032,7 @@ def generate_mypy_grpc_stubs(
         output.name = fd.name[:-6].replace("-", "_").replace(".", "/") + "_pb2_grpc.pyi"
         output.content = pkg_writer.write()
         if not quiet:
-            print("Writing mypy to", output.name, file=sys.stderr)
+            print("Writing mypy to", output.name, file=sys.stdout)
 
 
 @contextmanager


### PR DESCRIPTION
Hi
Thanks a lot for this really useful tool. I recently tried to integrate our existing protoc compilation (that uses this plugin) into Visual Studio, and ran into the issue that Visual Studio assumes the tool failed since the "Writing mypy to " lines are written to stderr.

Could you accept this change to log `Writing mypy to` lines to stdout instead? 

I'm not sure if there's a reason these are logged to stderr specifically, but I found this issue that was used to change mypy behaviour to not write all lines to stderr:  [Suggestion: write messages to stdout instead of stderr](https://github.com/python/mypy/issues/1051)

