### PR TITLE
Add mypy error code to type ignore.

### DIFF
--- a/mypy_protobuf/main.py
+++ b/mypy_protobuf/main.py
@@ -724,7 +724,7 @@ class PkgWriter(object):
         # _ServicerContext is supertyped by grpc.ServicerContext and grpc.aio.ServicerContext
         # So both can be used in the contravariant function parameter position.
         wl(
-            "class _ServicerContext({}, {}):  # type: ignore",
+            "class _ServicerContext({}, {}):  # type: ignore[misc, type-arg]",
             self._import("grpc", "ServicerContext"),
             self._import("grpc.aio", "ServicerContext"),
         )

--- a/test/generated/testproto/grpc/dummy_pb2_grpc.pyi
+++ b/test/generated/testproto/grpc/dummy_pb2_grpc.pyi
@@ -14,7 +14,7 @@ _T = typing.TypeVar('_T')
 class _MaybeAsyncIterator(collections.abc.AsyncIterator[_T], collections.abc.Iterator[_T], metaclass=abc.ABCMeta):
     ...
 
-class _ServicerContext(grpc.ServicerContext, grpc.aio.ServicerContext):  # type: ignore
+class _ServicerContext(grpc.ServicerContext, grpc.aio.ServicerContext):  # type: ignore[misc, type-arg]
     ...
 
 class DummyServiceStub:

--- a/test/generated/testproto/grpc/import_pb2_grpc.pyi
+++ b/test/generated/testproto/grpc/import_pb2_grpc.pyi
@@ -15,7 +15,7 @@ _T = typing.TypeVar('_T')
 class _MaybeAsyncIterator(collections.abc.AsyncIterator[_T], collections.abc.Iterator[_T], metaclass=abc.ABCMeta):
     ...
 
-class _ServicerContext(grpc.ServicerContext, grpc.aio.ServicerContext):  # type: ignore
+class _ServicerContext(grpc.ServicerContext, grpc.aio.ServicerContext):  # type: ignore[misc, type-arg]
     ...
 
 class SimpleServiceStub:


### PR DESCRIPTION
This supports running mypy with `ignore-without-code`.

Fixes #544